### PR TITLE
Replace unknown "builder" parameter in BlocProvider

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,7 +58,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider<AuthBloc>(builder: (_) => _auth),
+        BlocProvider<AuthBloc>(create: (_) => _auth),
       ],
       child: MaterialApp(
         home: AuthCheck(),


### PR DESCRIPTION
This parameter was previously deprecated and has now become unsupported.
It has been replaced in the `main.dart` file of the plugin example.