### PR TITLE
Firebase web default initialization through dart code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Update `/web/index.html` in the body tag.
   </script>
 ```
 
+As an alternative, you can avoid the`<script>` item with the `firebaseConfig` configuration by initializing the `FbApp` instance in your app as it is done in the plugin example `main.dart` file.
+
+```dart
+  final _app = FbApp(
+      apiKey: "API_KEY",
+      authDomain: "AUTH_DOMAIN",
+      databaseURL: "DATABASE_URL",
+      projectId: "PROJECT_ID",
+      storageBucket: "STORAGE_BUCKET",
+      messagingSenderId: "MESSAGING_SENDER_ID",
+      appId: "APP_ID",
+      measurementId: "MEASUREMENT_ID"
+  );
+```
+If the `<script>` item is present, it takes precedence over the initialization of the `FbApp` instance in dart code.
+
 Follow Installation Instructions for Mobile: https://pub.dev/packages/firebase_auth
 
 - Update `ios/Runner` and add the `GoogleService-Info.plist` downloaded from firebase

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,7 +58,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider<AuthBloc>(builder: (_) => _auth),
+        BlocProvider<AuthBloc>(create: (_) => _auth),
       ],
       child: MaterialApp(
         home: AuthCheck(),

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -18,7 +18,7 @@
   <script src="https://www.gstatic.com/firebasejs/6.3.3/firebase-storage.js"></script>
   <script src="https://www.gstatic.com/firebasejs/6.3.3/firebase-functions.js"></script>
 
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "API_KEY",
@@ -31,7 +31,7 @@
     };
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
-  </script>
+  </script> -->
 </body>
 
 </html>

--- a/lib/data/services/auth/web.dart
+++ b/lib/data/services/auth/web.dart
@@ -5,9 +5,23 @@ import 'impl.dart';
 
 class FBAuth implements FBAuthImpl {
   final FbApp app;
-  final _auth = auth();
+  Auth _auth;
 
-  FBAuth(this.app);
+  FBAuth(this.app) {
+    if (apps.isEmpty) {
+      initializeApp(
+          apiKey: this.app.apiKey,
+          authDomain: this.app.authDomain,
+          databaseURL: this.app.databaseURL,
+          projectId: this.app.projectId,
+          storageBucket: this.app.storageBucket,
+          messagingSenderId: this.app.messagingSenderId,
+          appId: this.app.appId,
+          measurementId: this.app.measurementId
+      );
+    }
+    _auth = auth();
+  }
 
   Future _setPersistenceWeb(Auth _auth) async {
     // try {


### PR DESCRIPTION
The plugin configuration includes the firebase configuration for web build right in dart code in the `main.dart`file.
But this configuration is never used.
This PR modifies the `web.dart` file in the plugin authentication code so the firebase initialization is done through dart code if the `<script>` item is removed in the index.html.
The Readme.md file has been edited to explain this behavior.