### PR TITLE
Fix currentUser() in FbClient

### DIFF
--- a/lib/data/services/rest_api/client.dart
+++ b/lib/data/services/rest_api/client.dart
@@ -9,8 +9,7 @@ import '../auth/impl.dart';
 import 'helpers/index.dart';
 
 class FbClient implements FBAuthImpl {
-  FbClient(
-    this.app, {
+  FbClient(this.app, {
     @required this.onSave,
     @required this.onLoad,
   }) {
@@ -44,7 +43,16 @@ class FbClient implements FBAuthImpl {
   Future<AuthUser> currentUser() async {
     FirestoreJsonAccessToken token = await _loadToken();
     if (token != null) {
-      return _getUser(token);
+      var result = await http.post(
+        'https://identitytoolkit.googleapis.com/v1/token?key=${app.apiKey}',
+        body: json.encode({
+          "refresh_token": token?.refreshToken,
+          "grant_type": 'refresh_token',
+          "returnSecureToken": true,
+        }),
+      );
+
+      return _getUser(await _saveRefreshToken(token, result));
     }
     return null;
   }
@@ -142,10 +150,30 @@ class FbClient implements FBAuthImpl {
   final Future Function(Map<String, dynamic>) onSave;
 
   Future<FirestoreJsonAccessToken> _saveToken(http.Response result) async {
-    final _data = json.decode(result.body);
-    final token = FirestoreJsonAccessToken(_data, DateTime.now());
+    var _data = json.decode(result.body);
+    _data['createdDate'] = DateTime.now().toIso8601String();
+
+    final token = FirestoreJsonAccessToken(_data);
     await onSave(_data);
     return token;
+  }
+
+  Future<FirestoreJsonAccessToken> _saveRefreshToken(FirestoreJsonAccessToken token, http.Response result) async {
+    final _data = json.decode(result.body);
+
+    Map<String, dynamic> refreshToken = Map<String, dynamic>();
+    refreshToken['kind'] = token.kind;
+    refreshToken['localId'] = token.localId;
+    refreshToken['email'] = token.email;
+    refreshToken['displayName'] = token.displayName;
+    refreshToken['idToken'] = _data['id_token'];
+    refreshToken['refreshToken'] = _data['refresh_token'];
+    refreshToken['expiresIn'] = _data['expires_in'];
+    refreshToken['createdDate'] = DateTime.now().toIso8601String();
+
+    final newToken = FirestoreJsonAccessToken(refreshToken);
+    await onSave(refreshToken);
+    return newToken;
   }
 
   Future<AuthUser> _getUser(FirestoreJsonAccessToken token) async {
@@ -178,7 +206,7 @@ class FbClient implements FBAuthImpl {
   Future<FirestoreJsonAccessToken> _loadToken() async {
     final _data = await onLoad();
     if (_data != null) {
-      final token = FirestoreJsonAccessToken(_data, DateTime.now());
+      final token = FirestoreJsonAccessToken(_data);
       return token;
     }
     return null;

--- a/lib/data/services/rest_api/client.dart
+++ b/lib/data/services/rest_api/client.dart
@@ -44,14 +44,6 @@ class FbClient implements FBAuthImpl {
   Future<AuthUser> currentUser() async {
     FirestoreJsonAccessToken token = await _loadToken();
     if (token != null) {
-      var result = await http.post(
-        'https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=${app.apiKey}',
-        body: json.encode({
-          "idToken": token?.idToken,
-          "returnSecureToken": true,
-        }),
-      );
-      token = await _saveToken(result);
       return _getUser(token);
     }
     return null;

--- a/lib/data/services/rest_api/helpers/token.dart
+++ b/lib/data/services/rest_api/helpers/token.dart
@@ -1,11 +1,13 @@
 class FirestoreJsonAccessToken {
-  FirestoreJsonAccessToken(this.json, this.createdAt);
+
+  FirestoreJsonAccessToken(this.json);
 
   final Map<String, dynamic> json;
 
-  String get refreshToken => json["refresh_token"];
+  String get refreshToken => json['refresh_token'] ?? json['refreshToken'] ;
 
-  final DateTime createdAt;
+  String get createdDate => json['createdAt'] as String;
+  DateTime get createdAt => DateTime.parse(createdDate);
 
   DateTime get expiresAt =>
       createdAt.add(new Duration(seconds: expiresInSeconds));
@@ -16,11 +18,22 @@ class FirestoreJsonAccessToken {
 
   String get kind => json['kind'] as String;
 
-  String get idToken => json['idToken'];
+  String get idToken => json['idToken'] ?? json['id_token'];
 
-  String get localId => json['localId'] as String;
+  String get localId => json['localId'] ?? json['user_id'] as String;
 
   int get expiresInSeconds => int.tryParse(json["expiresIn"]);
 
   bool get emailVerified => json['emailVerified'];
+
+  bool isExpired() {
+    bool expired = false;
+
+    if (createdAt != null) {
+      DateTime now = DateTime.now();
+      expired = createdAt.difference(now).inSeconds < 0;
+    }
+
+    return expired;
+  }
 }


### PR DESCRIPTION
The currentUser() method within the FbClient class, upon successful login, the token information is saved to fb_auth.json. Once application is closed and reopened the following occurs:

```dart
  @override
  Future<AuthUser> currentUser() async {
    FirestoreJsonAccessToken token = await _loadToken(); // 1. --- Loading saved token data from fb_auth.json
    if (token != null) {
      var result = await http.post( 
        'https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=${app.apiKey}',
        body: json.encode({
          "idToken": token?.idToken,
          "returnSecureToken": true,
        }),
      );
      token = await _saveToken(result); // 2. -- Sending results to _saveToken, which decodes json
      return _getUser(token); // 7. --- Incorrect token data (actually user
    }
    return null;
  }
```

```dart
  Future<FirestoreJsonAccessToken> _saveToken(http.Response result) async {
    final _data = json.decode(result.body); // 3. --- Data is decoded, which results in the data in the next code block 
    final token = FirestoreJsonAccessToken(_data, DateTime.now()); // 4. --- Unable to map the data, as it is not an access token, it is user data.
    await onSave(_data); // 5. --- This incorrect data is then saved to fb_auth.json
    return token; // 6. --- Incorrect token is passed back to currentUser()
  }
```
Results of 'results' http.Response json
```dart
{
    "kind": "identitytoolkit#GetAccountInfoResponse",
    "users": [
    {
        "localId": "xxxxxxxxxxxxxxxxxxxxxxxxxx",
        "email": "user@email.com",
        "displayName": "xxxxxxxxxxxxx",
        "passwordHash": "xxxxxxxxxx=",
        "emailVerified": false,
        "passwordUpdatedAt": 1587344957542,
        "providerUserInfo": [
        {
            "providerId": "password",
            "displayName": "xxxxxxxxxxx",
            "federatedId": "user@email.com",
            "email": "user@email.com",
            "rawId": "user@email.com"
        }],
        "validSince": "1587344957",
        "disabled": false,
        "lastLoginAt": "1588119233200",
        "createdAt": "1587344957542",
        "lastRefreshAt": "2020-04-29T00:13:53.200Z"
    }]
}
```

My changes allow it to work properly in my testing, as the loaded token gets sent to the _getUser() method properly, the user data is returned and usable within the application, and the application is able to continue. 

Please do let me know if I am mistaken on any of this.

Thanks,
-instance.id